### PR TITLE
added user name to .status file to allow the feature to work for multiple users

### DIFF
--- a/xrdPlanner/classes.py
+++ b/xrdPlanner/classes.py
@@ -1,4 +1,5 @@
 import os
+import pwd
 import sys
 import json
 import glob
@@ -56,7 +57,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # set path to settings folder
         self.path_settings = os.path.join(self.path_home, 'settings',)
         # set path to active settings token
-        self.path_settings_token = os.path.join(self.path_settings, '.active',)
+        self.path_settings_token = os.path.join(self.path_settings, f'.active_{pwd.getpwuid(os.getuid())[0]}',)
         # set path to default settings file
         self.path_settings_default = os.path.join(self.path_settings, 'default.json')
         # set path to current settings file


### PR DESCRIPTION
Trying to use a shared installation of xrdplanner on a cluster with many users and many user-groups I stumbled over the ".active" file. While the functionality is very neat, it prevented many users from starting xrdplanner as they missed the permissions to that file.

I added a change that the files are now getting the user name as suffix. This way one wouldn't try to load/overwrite another users .active file. Now the worst thing that can happen is that a user can not write to the directory in question. But this does not stop that person from using xrdplanner... just from starting up the next time with the settings they ended their last session.